### PR TITLE
feat(qtracer): add Gin middleware for New Relic tracing

### DIFF
--- a/go/utils/qmrz/mrz.go
+++ b/go/utils/qmrz/mrz.go
@@ -1,8 +1,11 @@
 package qmrz
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const TD1_CHAR_LEN = 30
@@ -325,4 +328,30 @@ func splitByN(s string, n int) []string {
 		result = append(result, s[i:end])
 	}
 	return result
+}
+
+func ParseMRZExpiry(expiry string) (time.Time, error) {
+	var ret time.Time
+	if len(expiry) != 6 {
+		return ret, errors.New("invalid expiry")
+	}
+
+	yearPart := expiry[:2]
+	monthPart := expiry[2:4]
+	dayPart := expiry[4:6]
+	baseCentury := (time.Now().Year() / 100) * 100
+
+	yy, err := strconv.Atoi(yearPart)
+	if err != nil {
+		return ret, err
+	}
+	fullYear := baseCentury + yy
+
+	date := fmt.Sprintf("%d-%s-%s", fullYear, monthPart, dayPart)
+
+	ret, err = time.Parse("2006-01-02", date)
+	if err != nil {
+		return ret, err
+	}
+	return ret, nil
 }

--- a/go/utils/qtracer/trace.go
+++ b/go/utils/qtracer/trace.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/gin-gonic/gin"
+	"github.com/newrelic/go-agent/v3/integrations/nrgin"
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
@@ -35,6 +37,10 @@ func (s *Span) Finish() {
 
 func InitTracer(data *newrelic.Application) {
 	app = data
+}
+
+func GinMiddleware() gin.HandlerFunc {
+	return nrgin.Middleware(app)
 }
 
 func StartGoroutineSpanFromContext(ctx context.Context, name string) (Span, context.Context) {


### PR DESCRIPTION
Add a new Gin middleware function to integrate New Relic tracing into Gin-based applications. This allows for better monitoring and tracing of HTTP requests handled by Gin.

feat(qmrz): add MRZ expiry parsing function

Introduce a new function to parse MRZ expiry dates into time.Time objects. This improves the handling of MRZ data by providing a structured way to process expiry dates.