### PR TITLE
fix(qtracer): set span context to ensure proper trace propagation

### DIFF
--- a/go/utils/qtracer/trace.go
+++ b/go/utils/qtracer/trace.go
@@ -72,6 +72,7 @@ func StartSpanFromContext(ctx context.Context, name string) (Span, context.Conte
 
 	seg := StartSegment(ctx, "[trace] "+name)
 	span.nrSegment = seg
+	span.ctx = ctx
 	span.md = GetMetadataFromContext(ctx)
 
 	return span, ctx


### PR DESCRIPTION
The span context was not being set, which could lead to trace propagation issues. This change ensures the context is properly assigned to the span for accurate tracing.